### PR TITLE
[edgedb] Remove `EDGEDB_PORT` env var

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "image": "mcr.microsoft.com/devcontainers/javascript-node:1-18-bullseye",
+    "image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm",
     "name": "Devcontainer Templates",
     "customizations": {
         "vscode": {

--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ To test a template locally, you can use `./test.sh`
 ```bash
 ./test.sh javascript-node-edgedb
 ```
+s

--- a/src/javascript-node-edgedb/.devcontainer/compose.yml
+++ b/src/javascript-node-edgedb/.devcontainer/compose.yml
@@ -28,7 +28,6 @@ services:
     # (Adding the "ports" property to this file will not forward from a Codespace.)
     environment:
       # this is purely for user reference, it's not used by the app
-      - EDGEDB_PORT=5656
       - EDGEDB_CLIENT_SECURITY=insecure_dev_mode
       # Use the same password as the database container.
       - *pwd

--- a/src/javascript-node-edgedb/.devcontainer/compose.yml
+++ b/src/javascript-node-edgedb/.devcontainer/compose.yml
@@ -28,6 +28,7 @@ services:
     # (Adding the "ports" property to this file will not forward from a Codespace.)
     environment:
       # this is purely for user reference, it's not used by the app
+      - EDGEDB_PORT=5656
       - EDGEDB_CLIENT_SECURITY=insecure_dev_mode
       # Use the same password as the database container.
       - *pwd

--- a/src/javascript-node-edgedb/.devcontainer/compose.yml
+++ b/src/javascript-node-edgedb/.devcontainer/compose.yml
@@ -24,11 +24,10 @@ services:
 
     # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
     network_mode: service:edgedb
-    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally. 
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
     environment:
       # this is purely for user reference, it's not used by the app
-      - EDGEDB_PORT=5656
       - EDGEDB_CLIENT_SECURITY=insecure_dev_mode
       # Use the same password as the database container.
       - *pwd

--- a/src/rust-edgedb/.devcontainer/compose.yml
+++ b/src/rust-edgedb/.devcontainer/compose.yml
@@ -24,11 +24,10 @@ services:
 
     # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
     network_mode: service:edgedb
-    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally. 
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
     environment:
       # this is purely for user reference, it's not used by the app
-      - EDGEDB_PORT=5656
       - EDGEDB_CLIENT_SECURITY=insecure_dev_mode
       # Use the same password as the database container.
       - *pwd

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 TEMPLATE_ID="$1"
 
+# Run tests for a specific template
+# Also ensure that containers ånd volumes are cleaned up afterward
+
 ./.github/actions/smoke-test/build.sh $TEMPLATE_ID
 ./.github/actions/smoke-test/test.sh $TEMPLATE_ID
 

--- a/test.sh
+++ b/test.sh
@@ -5,7 +5,9 @@ TEMPLATE_ID="$1"
 # Also ensure that containers ånd volumes are cleaned up afterward
 
 ./.github/actions/smoke-test/build.sh $TEMPLATE_ID
+BUILD_EXIT_CODE=$?
 ./.github/actions/smoke-test/test.sh $TEMPLATE_ID
+TEST_EXIT_CODE=$?
 
 # if test fails, we have to cleanup
 # no `devcontainer down` command yet... https://github.com/devcontainers/cli/issues/386
@@ -23,3 +25,10 @@ for VOLUME in $VOLUMES; do
     echo "Removing volume $(docker volume rm $VOLUME)"
 done
 rm -rf "${SRC_DIR}"
+
+# Exit with the exit code of the test script if it failed, otherwise with the exit code of the build script
+if [ $TEST_EXIT_CODE -ne 0 ]; then
+    exit $TEST_EXIT_CODE
+else
+    exit $BUILD_EXIT_CODE
+fi

--- a/test/javascript-node-edgedb/test-project/README.md
+++ b/test/javascript-node-edgedb/test-project/README.md
@@ -1,0 +1,3 @@
+# Test Project 
+
+We follow the [EdgeDB Quickstart](https://docs.edgedb.com/libraries/js) to make sure that the devcontainer is set up properly.

--- a/test/javascript-node-edgedb/test-project/dbschema/dbschema.esdl
+++ b/test/javascript-node-edgedb/test-project/dbschema/dbschema.esdl
@@ -1,0 +1,12 @@
+module default {
+  type Movie {
+    required title: str {
+      constraint exclusive;
+    };
+    multi actors: Person;
+  }
+
+  type Person {
+    required name: str;
+  }
+}

--- a/test/javascript-node-edgedb/test-project/edgedb.toml
+++ b/test/javascript-node-edgedb/test-project/edgedb.toml
@@ -1,0 +1,2 @@
+[edgedb]
+server-version = "5.6"

--- a/test/javascript-node-edgedb/test-project/package.json
+++ b/test/javascript-node-edgedb/test-project/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "javascript-node-edgedb-test-project",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "debug": "^4.3.7",
+    "edgedb": "^1.5.12",
+    "env-paths": "^3.0.0",
+    "esbuild": "^0.23.1",
+    "get-tsconfig": "^4.8.1",
+    "isexe": "^3.1.1",
+    "ms": "^2.1.3",
+    "resolve-pkg-maps": "^1.0.0",
+    "semver": "^7.6.3",
+    "shell-quote": "^1.8.1",
+    "undici-types": "^6.19.8",
+    "which": "^4.0.0"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "devDependencies": {
+    "@edgedb/generate": "^0.5.6",
+    "@types/node": "^22.9.1",
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/test/javascript-node-edgedb/test-project/query.ts
+++ b/test/javascript-node-edgedb/test-project/query.ts
@@ -1,0 +1,18 @@
+import * as edgedb from "edgedb";
+
+const client = edgedb.createClient();
+
+async function main() {
+    const result = await client.querySingle(`
+    select Movie {
+      title,
+      actors: {
+        name,
+      }
+    } filter .title = "Iron Man 2"
+  `);
+
+    console.log(JSON.stringify(result, null, 2));
+}
+
+main();

--- a/test/javascript-node-edgedb/test-project/seed.ts
+++ b/test/javascript-node-edgedb/test-project/seed.ts
@@ -1,0 +1,21 @@
+import * as edgedb from "edgedb";
+
+const client = edgedb.createClient();
+
+async function main() {
+    await client.execute(`
+    insert Person { name := "Robert Downey Jr." };
+    insert Person { name := "Scarlett Johansson" };
+    insert Movie {
+      title := <str>$title,
+      actors := (
+        select Person filter .name in {
+          "Robert Downey Jr.",
+          "Scarlett Johansson"
+        }
+      )
+    }
+  `, { title: "Iron Man 2" });
+}
+
+main();

--- a/test/javascript-node-edgedb/test-project/tsconfig.json
+++ b/test/javascript-node-edgedb/test-project/tsconfig.json
@@ -1,0 +1,110 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    // "noUncheckedSideEffectImports": true,             /* Check side effect imports. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "strictBuiltinIteratorReturn": true,              /* Built-in iterators are instantiated with a 'TReturn' type of 'undefined' instead of 'any'. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  }
+}

--- a/test/javascript-node-edgedb/test.sh
+++ b/test/javascript-node-edgedb/test.sh
@@ -1,12 +1,26 @@
 #!/bin/bash
-cd $(dirname "$0")
+
+set -e
+
 source test-utils.sh
 source edgedb.sh
 
-ls -al
-pwd
+cd $(dirname "$0")
 
 test_edgedb_connection
 
-# Report result
+cd test-project
+
+# initialize project
+check "initializing project" bash -c "edgedb project init --non-interactive --server-instance edgedb-docker --link"
+
+check "Creating initial edgedb migration" bash -c "edgedb migration create"
+check "Applying initial edgedb migration" bash -c "edgedb migrate"
+
+# running npm install
+check "Running npm install" bash -c "npm install"
+
+check "Running seed.ts" bash -c "npx tsx seed.ts"
+check "Running query.ts" bash -c "npx tsx query.ts"
+
 reportResults

--- a/test/rust-edgedb/test-project/Cargo.toml
+++ b/test/rust-edgedb/test-project/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "edgedb_client_example"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0.70"
+edgedb-derive = { git = "https://github.com/edgedb/edgedb-rust" }
+edgedb-tokio = { git = "https://github.com/edgedb/edgedb-rust" }
+edgedb-protocol = { git = "https://github.com/edgedb/edgedb-rust" }
+fastrand = "1.9.0"
+serde = { version = "1.0.159", features = ["derive"] }
+serde_json = "1.0.95"
+tokio = { version = "1.27.0", features = ["macros", "rt-multi-thread"] }
+uuid = { version = "1.3.0", features = ["serde"] }

--- a/test/rust-edgedb/test-project/README.md
+++ b/test/rust-edgedb/test-project/README.md
@@ -1,0 +1,5 @@
+# Test Project
+
+We follow the [EdgeDB minimum expression repo](https://github.com/Dhghomon/edgedb_rust_client_examples/) to make sure that the devcontainer is set up properly. 
+
+That repo has edgedb server version as "3.2" in the `edgedb.toml` file, but the code still works with v5.

--- a/test/rust-edgedb/test-project/dbschema/default.esdl
+++ b/test/rust-edgedb/test-project/dbschema/default.esdl
@@ -1,0 +1,74 @@
+module default {
+  # First part is the same schema as in the tutorial: https://www.edgedb.com/tutorial
+  type Account {
+    required property username -> str {
+      constraint exclusive;
+    };
+    multi link watchlist -> Content;
+    property some_json -> json;
+  }
+
+  type Person {
+    required property name -> str;
+    link filmography := .<actors[is Content];
+  }
+
+  abstract type Content {
+    required property title -> str;
+    multi link actors -> Person {
+      property character_name -> str;
+    };
+  }
+
+  type Movie extending Content {
+    property release_year -> int32;
+  }
+
+  type Show extending Content {
+    property num_seasons := count(.<show[is Season]);
+  }
+
+  type Season {
+    required property number -> int32;
+    required link show -> Show;
+  }
+
+  # The following types are exclusive to the repo
+  type BankCustomer {
+    required property name -> str {
+      constraint exclusive;
+    }
+    required property bank_balance -> int32; # bank balance in cents
+  }
+
+  type IsAStruct {
+    required property name -> str;
+    required property number -> int16;
+    required property is_cool -> bool;
+  }
+
+  type Citizen {
+    required property name -> str;
+    required property gov_id -> int32 {
+      constraint exclusive;
+    }
+    link spouse := (
+      with id := .gov_id,
+      cert := (select MarriageCertificate filter id in {.spouse_1.gov_id, .spouse_2.gov_id}),
+      select cert.spouse_2 if cert.spouse_1.gov_id = id else cert.spouse_1
+    )
+  }
+
+  type MarriageCertificate {
+    required link spouse_1 -> Citizen;
+    required link spouse_2 -> Citizen;
+  }
+};
+
+module test {
+  type Account {
+    required property username -> str {
+      constraint exclusive;
+    };
+  }
+}

--- a/test/rust-edgedb/test-project/edgedb.toml
+++ b/test/rust-edgedb/test-project/edgedb.toml
@@ -1,0 +1,2 @@
+[edgedb]
+server-version = "5.5"

--- a/test/rust-edgedb/test-project/src/lib.rs
+++ b/test/rust-edgedb/test-project/src/lib.rs
@@ -1,0 +1,95 @@
+use edgedb_protocol::{
+    descriptors::{Descriptor, TypePos},
+    errors::DecodeError,
+    queryable::{Decoder, DescriptorContext, DescriptorMismatch, Queryable},
+    serialization::decode::DecodeTupleLike,
+};
+
+// The code below shows the code generated from the Queryable macro in a more readable form
+// (with macro-generated qualified paths replaced with use statements).
+
+#[derive(Debug)]
+pub struct IsAStruct {
+    pub name: String,
+    pub number: i16,
+    pub is_cool: bool,
+}
+
+impl Queryable for IsAStruct {
+    fn decode(decoder: &Decoder, buf: &[u8]) -> Result<Self, DecodeError> {
+        let nfields = 3usize
+            + if decoder.has_implicit_id { 1 } else { 0 }
+            + if decoder.has_implicit_tid { 1 } else { 0 }
+            + if decoder.has_implicit_tname { 1 } else { 0 };
+        let mut elements = DecodeTupleLike::new_object(buf, nfields)?;
+        if decoder.has_implicit_tid {
+            elements.skip_element()?;
+        }
+        if decoder.has_implicit_tname {
+            elements.skip_element()?;
+        }
+        if decoder.has_implicit_id {
+            elements.skip_element()?;
+        }
+        let name = Queryable::decode_optional(decoder, elements.read()?)?;
+        let number = Queryable::decode_optional(decoder, elements.read()?)?;
+        let is_cool = Queryable::decode_optional(decoder, elements.read()?)?;
+        Ok(IsAStruct {
+            name,
+            number,
+            is_cool,
+        })
+    }
+
+    fn check_descriptor(
+        ctx: &DescriptorContext,
+        type_pos: TypePos,
+    ) -> Result<(), DescriptorMismatch> {
+        let desc = ctx.get(type_pos)?;
+        let shape = match desc {
+            Descriptor::ObjectShape(shape) => shape,
+            _ => return Err(ctx.wrong_type(desc, "str")),
+        };
+        let mut idx = 0;
+        if ctx.has_implicit_tid {
+            if !shape.elements[idx].flag_implicit {
+                return Err(ctx.expected("implicit __tid__"));
+            }
+            idx += 1;
+        }
+        if ctx.has_implicit_tname {
+            if !shape.elements[idx].flag_implicit {
+                return Err(ctx.expected("implicit __tname__"));
+            }
+            idx += 1;
+        }
+        if ctx.has_implicit_id {
+            if !shape.elements[idx].flag_implicit {
+                return Err(ctx.expected("implicit id"));
+            }
+            idx += 1;
+        }
+        let el = &shape.elements[idx];
+        if el.name != "name" {
+            return Err(ctx.wrong_field("name", &el.name));
+        }
+        idx += 1;
+        <String as Queryable>::check_descriptor(ctx, el.type_pos)?;
+        let el = &shape.elements[idx];
+        if el.name != "number" {
+            return Err(ctx.wrong_field("number", &el.name));
+        }
+        idx += 1;
+        <i16 as Queryable>::check_descriptor(ctx, el.type_pos)?;
+        let el = &shape.elements[idx];
+        if el.name != "is_cool" {
+            return Err(ctx.wrong_field("is_cool", &el.name));
+        }
+        idx += 1;
+        <bool as Queryable>::check_descriptor(ctx, el.type_pos)?;
+        if shape.elements.len() != idx {
+            return Err(ctx.field_number(shape.elements.len(), idx));
+        }
+        Ok(())
+    }
+}

--- a/test/rust-edgedb/test-project/src/main.rs
+++ b/test/rust-edgedb/test-project/src/main.rs
@@ -1,0 +1,413 @@
+use std::ops::Neg;
+
+use edgedb_client_example::IsAStruct;
+use edgedb_derive::Queryable;
+use edgedb_protocol::value::Value;
+use edgedb_tokio::TransactionOptions;
+use serde::Deserialize;
+use uuid::Uuid;
+
+// Used to add a random suffix to types with exclusive constraints.
+fn random_name() -> String {
+    std::iter::repeat_with(fastrand::alphanumeric)
+        .take(8)
+        .collect::<String>()
+}
+
+fn display_result(query: &str, res: &impl std::fmt::Debug) {
+    println!("Queried: {query}\nResult:  {res:?}\n");
+}
+
+// Represents the Account type in the schema, only implements Deserialize
+#[derive(Debug, Deserialize)]
+pub struct Account {
+    pub username: String,
+    pub id: Uuid,
+}
+
+// Also implements Queryable so is more convenient.
+// Note: Queryable requires query fields to be in the same order as the struct.
+// So `select Account { id, username }` will generate a DescriptorMismatch::WrongField error
+// whereas `select Account { username, id }` will not
+#[derive(Debug, Queryable)]
+pub struct QueryableAccount {
+    pub username: String,
+    pub id: Uuid,
+}
+
+// An edgedb(json) attribute on top of Deserialize and Queryable allows unpacking a struct from json returned from EdgeDB.
+#[derive(Debug, Deserialize, Queryable)]
+#[edgedb(json)]
+pub struct JsonQueryableAccount {
+    pub username: String,
+    pub id: Uuid,
+}
+
+#[derive(Debug, Deserialize, Queryable)]
+pub struct BankCustomer {
+    pub name: String,
+    pub bank_balance: i32,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+
+    // create_client() is the easiest way to create a client to access EdgeDB.
+    // If there are any problems with setting up the client automatically
+    // or if you need a more manual setup (e.g. reading from environment variables)
+    // it can be done step by step starting with a Builder. e.g.:
+    // let mut builder = edgedb_tokio::Builder::uninitialized();
+    // Read from environment variables:
+    // builder.read_env_vars().unwrap();
+    // Or read from named instance:
+    // builder.read_instance("name_of_your_instance_here").unwrap();
+    // let config = builder.build().unwrap();
+    // let client = edgedb_tokio::Client::new(&config);
+    let client = edgedb_tokio::create_client().await?;
+
+
+    // Now that the client is set up,
+    // first just select a string and return it. .query_required_single
+    // can be used here as the cardinality is guaranteed to be one (EdgeDB
+    // will return a set with only one item).
+    let query = "select 'This is a query fetching a string'";
+    let res: String = client.query_required_single(query, &()).await?;
+    display_result(query, &res);
+    assert_eq!(res, "This is a query fetching a string");
+
+    // You can of course use the .query() method in this case - you'll just have
+    // a Vec<String> with a single item inside.
+    let query = "select 'This is a query fetching a string'";
+    let res: Vec<String> = client.query(query, &()).await?;
+    display_result(query, &res);
+    assert_eq!(res.get(0).unwrap(), "This is a query fetching a string");
+
+    // Selecting a tuple with two scalar types this time
+    let query = "select ('Hi', 9.8);";
+    let res: Value = client.query_required_single(query, &()).await?;
+    display_result(query, &res);
+    assert_eq!(
+        res,
+        Value::Tuple(vec![Value::Str("Hi".into()), Value::Float64(9.8)])
+    );
+    assert_eq!(format!("{res:?}"), r#"Tuple([Str("Hi"), Float64(9.8)])"#);
+
+    // You can pass in arguments too via a tuple
+    let query = "select (<str>$0, <int32>$1);";
+    let arguments = ("Hi there", 10);
+    let res: Value = client.query_required_single(query, &arguments).await?;
+    display_result(query, &res);
+    assert_eq!(format!("{res:?}"), r#"Tuple([Str("Hi there"), Int32(10)])"#);
+
+    // EdgeDB itself takes named arguments but the client expects positional arguments ($0, $1, $2, etc.)
+    // So this will not work:
+    let query = "select {(<str>$arg1, <int32>$arg2)};";
+    let arguments = ("Hi there", 10);
+    let res: Result<Value, _> = client.query_required_single(query, &arguments).await;
+    display_result(query, &res);
+    assert!(format!("{res:?}").contains("expected positional arguments, got arg1 instead of 0"));
+
+    // Arguments in queries are used as type inference for the EdgeDB compiler,
+    // not to dynamically cast queries from the Rust side. So this will return an error:
+    let query = "select <int32>$0";
+    let argument = 9i16; // Rust client will expect an int16
+    let res: Result<Value, _> = client.query_required_single(query, &(argument,)).await;
+    display_result(query, &res);
+    assert!(format!("{res:?}").contains("expected std::int16"));
+
+    // Note: most scalar types have an exact match with Rust (e.g. an int32 matches a Rust i32)
+    // while the internals of those that don't can be seen on the edgedb_protocol crate.
+    // e.g. a BigInt can be seen here https://docs.rs/edgedb-protocol/latest/edgedb_protocol/model/struct.BigInt.html
+    // and looks like this and implements From for all the types you would expect:
+    //
+    // pub struct BigInt {
+    //     pub(crate) negative: bool,
+    //     pub(crate) weight: i16,
+    //     pub(crate) digits: Vec<u16>,
+    // }
+    // Thus this query will not work:
+    let query = "select <bigint>$0";
+    let argument = 20;
+    let res: Result<Value, _> = client.query_required_single(query, &(argument,)).await;
+    display_result(query, &res);
+    assert!(format!("{res:?}").contains("expected std::int32"));
+
+    // But this one will:
+    let query = "select <bigint>$0";
+    let bigint_arg = edgedb_protocol::model::BigInt::from(20);
+    let res: Value = client.query_required_single(query, &(bigint_arg,)).await?;
+    display_result(query, &res);
+    assert_eq!(
+        format!("{res:?}"),
+        "BigInt(BigInt { negative: false, weight: 0, digits: [20] })"
+    );
+    // To view the rest of the implementations for scalar types, see here:
+    // https://docs.rs/edgedb-protocol/latest/edgedb_protocol/model/index.html
+
+
+    // Next insert a user account. Not 'select'ing anything in particular
+    // So it will return a Uuid (the object's id)
+    let name = random_name();
+    let query = "insert Account { username := <str>$0 };";
+    let res: Value = client.query_required_single(query, &(name,)).await?;
+    // This time we queried for a Value, which is a big enum of all the types
+    // that EdgeDB supports. Just printing it out includes both the shape info and the fields
+    display_result(query, &res);
+
+    // We know it's a Value::Object. Let's match on the enum
+    match &res {
+        // The fields property is a Vec<Option<Value>>. In this case we'll only have one:
+        Value::Object { shape: _, fields } => {
+            println!("Insert worked, Fields are: {fields:?}\n");
+            for field in fields {
+                match field {
+                    Some(Value::Uuid(uuid)) => {
+                        println!("Only returned one field, a Uuid: {uuid}\n")
+                    }
+                    _other => println!("This shouldn't happen"),
+                }
+            }
+        }
+        _other => println!("This shouldn't happen"),
+    };
+
+    // Or even shorter with if let:
+    if let Value::Object { shape: _, fields } = res {
+        if let Some(Some(Value::Uuid(id))) = fields.get(0) {
+            println!("Found an id: {id}\n");
+        }
+    }
+
+    // Now do the same insert as before but we'll select a shape to return instead of just the id.
+    let name = random_name();
+    let query = "select (
+        insert Account { username := <str>$0 }
+    ) {
+        username, 
+        id
+      };";
+    if let Value::Object { shape: _, fields } =
+        client.query_required_single(query, &(name,)).await?
+    {
+        // This time we have more than one field in the fields property
+        for field in fields {
+            println!("Got a field: {field:?}");
+        }
+        println!();
+    }
+
+
+    // Now the same query as above, except we'll return it as json.
+    let name = random_name();
+    let query = "select (
+        insert Account { username := <str>$0 }
+    ) {
+        username, 
+        id
+    };";
+
+    // .query_single_json returns a Result<Option<Json>>
+    let json_res = client.query_single_json(query, &(name,)).await?.unwrap();
+    println!("Json res is pretty easy:");
+    display_result(query, &json_res);
+
+    // We know there will only be one result so use query_single_json; otherwise it will return a map of json
+    // Note the fine difference between the two:
+    // "{"id": "1094b032-d8e7-11ed-acbd-abc1449ffb3b", "username": "rUQdaH9T"}" <-- query_single_json
+    // "[{"id": "1097e5cc-d8e7-11ed-acbd-db8520ede217", "username": "h64HSxH8"}]" <- query_json
+
+
+    // You can turn this into a serde Value and access using square brackets:
+    let as_value: serde_json::Value = serde_json::from_str(&json_res)?;
+    println!("Name: {},\nId: {}.\n", as_value["username"], as_value["id"]);
+
+    // But Deserialize is much more common (and rigorous).
+    // Our Account struct implements Deserialize so we can use serde_json to deserialize the result into an Account.
+    // (Note: unpacking a struct from json via Queryable and edgedb(json) is shown further below)
+    let as_account: Account = serde_json::from_str(&json_res)?;
+    println!("Deserialized: {as_account:?}\n");
+
+
+    // The instance at this point is guaranteed to have more than one Account.
+    // Using query_required_single will now return an error:
+    let query = "select Account;";
+    let res: Result<Value, _> = client.query_required_single(query, &()).await;
+    assert!(format!("{res:?}")
+        .contains("has cardinality MANY which does not match the expected cardinality ONE"));
+
+    // The edgedb-derive crate has a built-in Queryable macro that lets us just query without having
+    // to cast to json. Same query as before:
+    let name = random_name();
+    let query = "select (
+        insert Account { username := <str>$0 }
+    ) {
+        username, 
+        id
+      };";
+    let as_queryable_account: QueryableAccount =
+        client.query_required_single(query, &(name,)).await?;
+    println!("As QueryableAccount, no need for intermediate json: {as_queryable_account:?}\n");
+
+    // Click on the IsAStruct struct to see the code generated from the Queryable macro
+    let query = r#"with nice_struct := (insert IsAStruct {
+        name := 'Nice name',
+        number := 10,
+        is_cool := true
+        }),
+        select nice_struct {
+        name,
+        number,
+        is_cool
+        };"#;
+    let res: IsAStruct = client.query_required_single(query, &()).await?;
+    display_result(query, &res);
+
+    // And changing the order of the fields from `username, id` to `id, username` will
+    // return a DescriptorMismatch::WrongField error
+    let name = random_name();
+    let query = "select (
+        insert Account { username := <str>$0 }
+    ) {
+        id, 
+        username
+      };";
+    let wrong_order: Result<QueryableAccount, _> =
+        client.query_required_single(query, &(name,)).await;
+    display_result(query, &wrong_order);
+    assert!(format!("{wrong_order:?}")
+        .contains("WrongField { unexpected: \"id\", expected: \"username\" }"));
+
+    // An example of using Queryable and edgedb(json) to directly unpack a struct from json:
+    let query = "select <json>Account { username, id }";
+    let json_queryable_accounts: Vec<JsonQueryableAccount> = client.query(query, &()).await?;
+    display_result(query, &json_queryable_accounts.get(0));
+
+    // The execute method doesn't return anything (a successful execute returns an Ok(()))
+    // which is convenient for things like updates or commands where we don't care about getting
+    // an output if it works
+    client
+        .execute("update Account set {username := .username ++ '!'};", &())
+        .await?;
+    // Or commands.
+    client
+        .execute("create superuser role project;", &())
+        .await
+        .unwrap_or(println!("Already created"));
+    client
+        .execute("alter role project set password := 'STRONGpassword';", &())
+        .await?;
+
+    // Returns Ok(()) upon success but error info will be returned of course
+    let command = client.execute("create type MyType {};", &()).await;
+    assert!(command
+        .unwrap_err()
+        .to_string()
+        .contains("bare DDL statements are not allowed"));
+
+    // ***** TRANSACTIONS *****
+
+    // Customer1 has an account with 110 cents in it.
+    // Customer2 has an account with 90 cents in it.
+    // Customer1 is going to send 10 cents to Customer 2. This will be a transaction because
+    // we don't want the case to ever occur - even for a split second -  where one account
+    // has sent money while the other has not received it yet. The operation must be atomic,
+    // so we will use a transaction.
+
+    // After the transaction is over, each customer should have 100 cents.
+
+    // Customers need unique names, so make them random:
+    let (customer_1_name, customer_2_name) = (
+        format!("Customer_{}", random_name()),
+        format!("Customer_{}", random_name()),
+    );
+
+    // First insert the customers in the database
+    let customers_before: Vec<BankCustomer> = client
+        .query(
+            "select {
+            (insert BankCustomer {
+            name := <str>$0,
+            bank_balance := 110
+            }),
+            (insert BankCustomer {
+            name := <str>$1,
+            bank_balance := 90
+            })
+            } {
+            name,
+            bank_balance
+            };",
+            &(&customer_1_name, &customer_2_name),
+        )
+        .await?;
+
+    println!("Customers before the transaction: {customers_before:#?}\n");
+
+    // Clone the client and get a reference to the names to avoid lifetime issues inside the closure
+    let cloned_client = client.clone();
+    let sender = &customer_1_name;
+    let receiver = &customer_2_name;
+
+    let balance_query = "select BankCustomer { name, bank_balance } filter .name = <str>$0";
+    let send_query = "update BankCustomer filter .name = <str>$0
+            set { bank_balance := .bank_balance + <int32>$1 }";
+    let amount = 10;
+
+    cloned_client
+        .transaction(|mut conn| async move {
+            let customer: BankCustomer = conn
+                .query_required_single(balance_query, &(sender,))
+                .await?;
+            if customer.bank_balance < amount {
+                println!("Not enough money to send, bailing from transaction");
+                return Ok(());
+            };
+            conn.execute(send_query, &(sender, amount.neg())).await?;
+            conn.execute(send_query, &(receiver, amount)).await?;
+            Ok(())
+        })
+        .await?;
+
+    let query = "select BankCustomer { name, bank_balance } filter .name in {<str>$0, <str>$1}";
+    let customers_after: Vec<BankCustomer> = client.query(query, &(sender, receiver)).await?;
+    assert!(customers_after[0].bank_balance == 100);
+    assert!(customers_after[1].bank_balance == 100);
+    println!("And now the customers are: {customers_after:#?}\n");
+
+    // ***** CONFIGURATION *****
+
+    // Client configuration can be changed with various "with_" methods
+    // such as with_config, with_globals, and with_default_module
+    // These create a shallow copy of the client which allows using
+    // multiple clients with different configurations.
+
+    // Take this query for example:
+    let query = "select Account {username, id};";
+
+    // The schema also has a module called 'test' in addition to 'default',
+    // and the test module also has its own type called Account type.
+    // Here we make a client from the original one that uses the test module
+    // as its default instead of the module called 'default'.
+    let test_client = client.with_default_module(Some("test"));
+
+    // No data has been inserted yet so no objects will be returned
+    let res: Result<Vec<QueryableAccount>, _> = test_client.query(query, &()).await;
+    assert_eq!(format!("{res:?}"), "Ok([])");
+
+    // The original client is still around and will look inside the default
+    // module, so in this case the query will return a number of results.
+    let res: Vec<QueryableAccount> = client.query(query, &()).await?;
+    assert!(res.len() > 1);
+
+    // Many other clients with different can be created, all separate
+    // from the original client
+    let _read_only_transaction_client =
+        client.with_transaction_options(TransactionOptions::default().read_only(true));
+    // let _immediate_retry_once_client = client.with_retry_options(RetryOptions::default()
+    // .with_rule(RetryCondition::TransactionConflict,
+    //     1, |_| {
+    //         std::time::Duration::from_millis(0)
+    //     }));
+
+    Ok(())
+}

--- a/test/rust-edgedb/test.sh
+++ b/test/rust-edgedb/test.sh
@@ -5,5 +5,15 @@ source edgedb.sh
 
 test_edgedb_connection
 
+cd test-project
+
+# initialize project
+check "initializing project" bash -c "edgedb project init --non-interactive --server-instance edgedb-docker --link"
+
+check "Creating initial edgedb migration" bash -c "edgedb migration create"
+check "Applying initial edgedb migration" bash -c "edgedb migrate"
+
+check "Running npm install" bash -c "cargo run"
+
 # Report result
 reportResults


### PR DESCRIPTION
it seems to conflict with other edgedb connection methods. 

When I set a project, I would sometimes get `Unexpected connection error: AuthenticationError: authentication failed` when using the port var

I should also add some more tests for the edgedb templates. Maybe an example project to push some changes to the db.